### PR TITLE
Add steam and savegame locations Flatpak Steam installs in Linux

### DIFF
--- a/backend/engine/finders/linux_finder.py
+++ b/backend/engine/finders/linux_finder.py
@@ -1,18 +1,21 @@
 import os
-from xdg import XDG_DATA_HOME
+from xdg import XDG_DATA_HOME, HOME
 
 STEAM_DIR = 'Steam'
 SAVE_DIR = 'Paradox Interactive/Stellaris/save games'
+FLATPAK_DIR = '.var/app/com.valvesoftware.Steam/.local/share'
 
 def find_steam():
-    path = os.path.join(str(XDG_DATA_HOME), STEAM_DIR)
-    if os.path.isdir(path):
-        return path
-    path = os.path.expanduser('~/.steam/steam')
-    if os.path.isdir(path):
-        return path
+    paths = [os.path.join(str(XDG_DATA_HOME), STEAM_DIR),   # old default path
+             os.path.expanduser('~/.steam/steam'),  # new default path
+             os.path.join(str(HOME), FLATPAK_DIR, STEAM_DIR)]  # path for flatpak steam version
+
+    for path in paths:
+        if os.path.isdir(path):
+            return path
     return None
 
 def get_os_specific_save_dirs():
-    path = os.path.join(str(XDG_DATA_HOME), SAVE_DIR)
-    return [path]
+    paths = [os.path.join(str(XDG_DATA_HOME), SAVE_DIR),
+             os.path.join(str(HOME), FLATPAK_DIR, SAVE_DIR)]  # flatpak
+    return paths


### PR DESCRIPTION
When Steam is installed through the Flatpak package manager it is installed to `~/.var/app/com.valvesoftware.Steam/.local/share/`. Added the new paths. Seems to be working on Ubuntu 20.10, I can't verify other distros.

Same issue with saves not being detected until a manual save is performed as mentioned [here](https://github.com/benreid24/Stellaru/pull/37#issue-509131794).