### PR TITLE
fix(leaderboard): filter by empires that come and go

### DIFF
--- a/frontend/src/Monitor/Leaderboard/Selectors.ts
+++ b/frontend/src/Monitor/Leaderboard/Selectors.ts
@@ -21,7 +21,7 @@ const getFederationMembers: (snap: any, fid: number) => number[] = (snap, fid) =
 }
 
 const empireNotFiltered: (snap: any, eid: number, filter: FilterState) => boolean = (snap, eid, filter) => {
-    const t = snap['leaderboard']['empire_summaries'][eid]['type'];
+    const t = snap['leaderboard']['empire_summaries'][eid]?.['type'];
     if (t === 'player') {
         return filter.showPlayers;
     }


### PR DESCRIPTION
It crashed due this when selecting group by empires. Most likely due new empire spawning and/or capitulating.