### PR TITLE
fix: dont crash on missing data points

### DIFF
--- a/backend/engine/extraction/isolation/v2.py
+++ b/backend/engine/extraction/isolation/v2.py
@@ -133,7 +133,7 @@ def get_empire(state, empire):
 
     empire_type = 'player'
     if player_name == 'AI':
-        empire_type = 'fallen_empire' if 'fallen_empire' in data['personality'] else 'regular_ai'
+        empire_type = 'fallen_empire' if 'personality' in data and 'fallen_empire' in data['personality'] else 'regular_ai'
 
     relic_points = 0
     if 'relics' in data:

--- a/backend/engine/extraction/postprocessors/comparison_processor.py
+++ b/backend/engine/extraction/postprocessors/comparison_processor.py
@@ -21,7 +21,7 @@ class ComparisonProcessor(PostProcessor):
         str_comp = {}
         fleet_strength = empire['fleets']['fleet_power']['total']
         for oid, oempire in data.get_full_snapshot()['empires'].items():
-            names[oid] = oempire['name']
+            names[oid] = oempire.get('name', 'Unknown Name')
             try:
                 if oid == eid or not self.isolation_layer.empire_valid(data.get_gamestate(), oid):
                     continue

--- a/backend/stellaru_api/views.py
+++ b/backend/stellaru_api/views.py
@@ -102,10 +102,12 @@ def get_empires(request):
             return _make_error(f'Invalid save file: {save_file}')
 
         save = engine.add_save(save_watcher, request.session['id'])
+        if not save:
+            return _make_error(f'Invalid save: {save_watcher.name()}')
         empires = [{
             'id': empire_id,
-            'name': save['snaps'][-1]['empires'][empire_id]['name'],
-            'player': save['snaps'][-1]['empires'][empire_id]['player_name']
+            'name': save['snaps'][-1]['empires'][empire_id].get('name', 'Unknown name'),
+            'player': save['snaps'][-1]['empires'][empire_id].get('player_name', 'Unknown player name'),
         } for empire_id in save['snaps'][-1]['empires']]
 
         return JsonResponse({

--- a/frontend/src/Monitor/Leaderboard/Selectors.ts
+++ b/frontend/src/Monitor/Leaderboard/Selectors.ts
@@ -55,8 +55,8 @@ export const findEmpireName = (eid: number, data: any[]) => {
 }
 
 export const findPlayerName = (eid: number, data: any[]) => {
-    for (let i = data.length - 1; i >= 0; i -= 1) {
-        const summaries = data[i]['leaderboard']['empire_summaries'];
+    for (const datum of data) {
+        const summaries = datum?.['leaderboard']?.['empire_summaries'];
         if (eid in summaries) {
             return summaries[eid]['player_name'];
         }

--- a/frontend/src/Monitor/Leaderboard/StatusBoard.tsx
+++ b/frontend/src/Monitor/Leaderboard/StatusBoard.tsx
@@ -160,16 +160,11 @@ const GroupEditor: React.FC<GroupEditorProps> = ({open, onRequestClose, data}) =
         removeGroup
     } = useLeaderboardContext();
 
-    const eids = data && data.length > 0 ? 
-        Object.keys(data[data.length-1]['leaderboard']['empire_summaries']).map(Number)
-        : [];
-    const empireList = eids.map(eid => {
-        const empire = data[data.length-1]['leaderboard']['empire_summaries'][eid];
-        return {
-            id: eid,
-            label: `${empire['name']} (${empire['type']})`
-        } as LabeledEmpire;
-    });
+    const eids = Object.entries(data?.[data?.length-1]?.['leaderboard']?.['empire_summaries'] ?? [])
+    const empireList = eids.map(([eid, empire]) => ({
+        id: Number(eid),
+        label: `${(empire as any)?.name} (${(empire as any)?.type})`
+    } as LabeledEmpire));
 
     const renderedGroups = Object.values(groupState.groups).map(g => (
         <GroupRow


### PR DESCRIPTION
In my last playthrough Stellaru crashed when loading a save because backend had an error.

This is a workaround so that it's possible to still use Stellaru. Will need to select narrower date range so that last datapoint exists.

Proper solution would be to find why data doesn't exist, but for now this already is an improvement.