### PR TITLE
fix(leaderboard): selectable Fleet Power in custom

### DIFF
--- a/frontend/src/Monitor/Leaderboard/Charts/FleetPower.tsx
+++ b/frontend/src/Monitor/Leaderboard/Charts/FleetPower.tsx
@@ -18,7 +18,7 @@ const Labels: Record<ChartedValue, string> = {
     'fleet_size': 'Total Fleet Size'
 }
 
-const Name = 'Fleet Power';
+const Name = 'Fleet Power Leaderboard';
 
 const useStyles = makeStyles((theme) => ({
     formControl: {


### PR DESCRIPTION
"Fleet Power" from Leaderboard has a name clash with already existing "Fleet Power". That is a problem because can't select it in the custom charts. Rename fixed it.